### PR TITLE
Changing is_search_visible to is_search_present

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -81,8 +81,8 @@ class BasePage(Page):
             return ProfilePage(self.testsetup)
 
         @property
-        def is_search_visible(self):
-            return self.is_element_visible(self._search_locator)
+        def is_search_present(self):
+            return self.is_element_present(self._search_locator)
 
         @property
         def browser_id_info(self):

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -23,7 +23,7 @@ class TestDemo:
         Assert.true(demo_pg.header.is_demos_link_visible)
         Assert.true(demo_pg.header.is_learning_link_visible)
         Assert.true(demo_pg.header.is_community_link_visible)
-        Assert.true(demo_pg.header.is_search_visible)
+        Assert.true(demo_pg.header.is_search_present)
 
     @pytest.mark.nondestructive
     def test_footer_links(self, mozwebqa):

--- a/tests/test_dev_derby.py
+++ b/tests/test_dev_derby.py
@@ -21,7 +21,7 @@ class TestDevDerby:
         Assert.true(derby_pg.header.is_demos_link_visible)
         Assert.true(derby_pg.header.is_learning_link_visible)
         Assert.true(derby_pg.header.is_community_link_visible)
-        Assert.true(derby_pg.header.is_search_visible)
+        Assert.true(derby_pg.header.is_search_present)
 
     @pytest.mark.nondestructive
     def test_are_footer_links_visible(self, mozwebqa):

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -21,7 +21,7 @@ class TestHome:
         Assert.true(home_pg.header.is_demos_link_visible)
         Assert.true(home_pg.header.is_learning_link_visible)
         Assert.true(home_pg.header.is_community_link_visible)
-        Assert.true(home_pg.header.is_search_visible)
+        Assert.true(home_pg.header.is_search_present)
 
     @pytest.mark.nondestructive
     def test_footer_links(self, mozwebqa):

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -32,7 +32,7 @@ class TestLearning:
         Assert.true(learning_pg.header.is_demos_link_visible)
         Assert.true(learning_pg.header.is_learning_link_visible)
         Assert.true(learning_pg.header.is_community_link_visible)
-        Assert.true(learning_pg.header.is_search_visible)
+        Assert.true(learning_pg.header.is_search_present)
 
     @pytest.mark.nondestructive
     def test_page_elements_are_visible(self, mozwebqa):


### PR DESCRIPTION
The BrowserID button on http://developer.mozilla.org displays a message to
users which covers the search button and causes the is_element_visible
function to fail. Switching to is_element_present fixes this.
