### PR TITLE
Xfailing because the Dev Derby will be on hiatus from August to October

### DIFF
--- a/tests/test_dev_derby.py
+++ b/tests/test_dev_derby.py
@@ -60,6 +60,7 @@ class TestDevDerby:
         Assert.true(derby_page.is_prizes_image_visible)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("config.getvalue('base_url') == 'https://developer.mozilla.org'", reason="The Dev Derby will be on hiatus from August to October")
     def test_judge_photos_visible(self, mozwebqa):
         derby_page = DerbyPage(mozwebqa)
         derby_page.go_to_page()
@@ -72,6 +73,7 @@ class TestDevDerby:
             Assert.true(judge.is_photo_visible)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("config.getvalue('base_url') == 'https://developer.mozilla.org'", reason="The Dev Derby will be on hiatus from August to October")
     def test_are_previous_challenges_visible(self, mozwebqa):
         derby_page = DerbyPage(mozwebqa)
         derby_page.go_to_page()


### PR DESCRIPTION
The Dev Derby will be on hiatus from August to October while they work on revamping the contest series. And some elements are missing from the page through this time (judges tabs for example)
https://developer.mozilla.org/en-US/demos/devderby
https://hacks.mozilla.org/2013/06/announcing-an-administrative-change-to-the-dev-derby/
